### PR TITLE
Changing Update record failure semantics to be consistent with inserts

### DIFF
--- a/hoodie-client/src/main/java/com/uber/hoodie/io/HoodieInsertHandle.java
+++ b/hoodie-client/src/main/java/com/uber/hoodie/io/HoodieInsertHandle.java
@@ -90,6 +90,8 @@ public class HoodieInsertHandle<T extends HoodieRecordPayload> extends HoodieIOH
             record.deflate();
             recordsWritten++;
         } catch (Throwable t) {
+            // Not throwing exception from here, since we don't want to fail the entire job
+            // for a single record
             status.markFailure(record, t);
             logger.error("Error writing record " + record, t);
         }

--- a/hoodie-client/src/main/java/com/uber/hoodie/table/HoodieCopyOnWriteTable.java
+++ b/hoodie-client/src/main/java/com/uber/hoodie/table/HoodieCopyOnWriteTable.java
@@ -391,7 +391,8 @@ public class HoodieCopyOnWriteTable<T extends HoodieRecordPayload> extends Hoodi
         HoodieUpdateHandle upsertHandle =
                 new HoodieUpdateHandle<>(config, commitTime, metadata, recordItr, fileLoc);
         if (upsertHandle.getOldFilePath() == null) {
-            logger.error("Error in finding the old file path at commit " + commitTime);
+            throw new HoodieUpsertException("Error in finding the old file path at commit " +
+                    commitTime +" at fileLoc: " + fileLoc);
         } else {
             Configuration conf = FSUtils.getFs().getConf();
             AvroReadSupport.setAvroReadSchema(conf, upsertHandle.getSchema());
@@ -414,9 +415,9 @@ public class HoodieCopyOnWriteTable<T extends HoodieRecordPayload> extends Hoodi
                 upsertHandle.close();
             }
         }
+        //TODO(vc): This needs to be revisited
         if (upsertHandle.getWriteStatus().getPartitionPath() == null) {
-            logger.info(
-                    "Upsert Handle has partition path as null " + upsertHandle.getOldFilePath()
+            logger.info("Upsert Handle has partition path as null " + upsertHandle.getOldFilePath()
                             + ", " + upsertHandle.getWriteStatus());
         }
         return Collections.singletonList(Collections.singletonList(upsertHandle.getWriteStatus())).iterator();


### PR DESCRIPTION
 - Don't skip, but writes the same old record again now
 - Marks the correspoinding HoodieRecord as failure to be handed back to the client