### PR TITLE
Pass in String StroageLevel for WriteStatus

### DIFF
--- a/hoodie-client/src/main/java/com/uber/hoodie/config/HoodieWriteConfig.java
+++ b/hoodie-client/src/main/java/com/uber/hoodie/config/HoodieWriteConfig.java
@@ -277,8 +277,8 @@ public class HoodieWriteConfig extends DefaultHoodieConfig {
             return this;
         }
 
-        public Builder withWriteStatusStorageLevel(StorageLevel level) {
-            props.setProperty(WRITE_STATUS_STORAGE_LEVEL, level.toString());
+        public Builder withWriteStatusStorageLevel(String level) {
+            props.setProperty(WRITE_STATUS_STORAGE_LEVEL, level);
             return this;
         }
 


### PR DESCRIPTION
When setting the StorageLevel of WriteStatus, directly pass in the name string instead of using .toString()