### PR TITLE
adding support for Viewfs scheme

### DIFF
--- a/hoodie-client/src/main/java/com/uber/hoodie/io/storage/HoodieWrapperFileSystem.java
+++ b/hoodie-client/src/main/java/com/uber/hoodie/io/storage/HoodieWrapperFileSystem.java
@@ -52,6 +52,7 @@ public class HoodieWrapperFileSystem extends FileSystem {
         SUPPORT_SCHEMES = new HashSet<>(2);
         SUPPORT_SCHEMES.add("file");
         SUPPORT_SCHEMES.add("hdfs");
+        SUPPORT_SCHEMES.add("viewfs");
     }
 
     private ConcurrentMap<String, SizeAwareFSDataOutputStream> openStreams =

--- a/hoodie-client/src/main/java/com/uber/hoodie/io/storage/HoodieWrapperFileSystem.java
+++ b/hoodie-client/src/main/java/com/uber/hoodie/io/storage/HoodieWrapperFileSystem.java
@@ -662,7 +662,7 @@ public class HoodieWrapperFileSystem extends FileSystem {
             newScheme = HOODIE_SCHEME_PREFIX + scheme;
         } else {
             throw new IllegalArgumentException(
-                "BlockAlignedAvroParquetWriter does not support schema " + scheme);
+                "BlockAlignedAvroParquetWriter does not support scheme " + scheme);
         }
         return newScheme;
     }

--- a/hoodie-client/src/main/java/com/uber/hoodie/io/storage/HoodieWrapperFileSystem.java
+++ b/hoodie-client/src/main/java/com/uber/hoodie/io/storage/HoodieWrapperFileSystem.java
@@ -49,7 +49,7 @@ public class HoodieWrapperFileSystem extends FileSystem {
     public static final String HOODIE_SCHEME_PREFIX = "hoodie-";
 
     static {
-        SUPPORT_SCHEMES = new HashSet<>(2);
+        SUPPORT_SCHEMES = new HashSet<>(3);
         SUPPORT_SCHEMES.add("file");
         SUPPORT_SCHEMES.add("hdfs");
         SUPPORT_SCHEMES.add("viewfs");


### PR DESCRIPTION
When the default URI has viewfs (or the configuration object has viewfs URI), hoodie throws unsupported scheme exception. Adding this scheme to fix that issue.