### PR TITLE
Change from deprecated closeQuietly to try with resources

### DIFF
--- a/hoodie-common/src/main/java/com/uber/hoodie/common/table/timeline/HoodieActiveTimeline.java
+++ b/hoodie-common/src/main/java/com/uber/hoodie/common/table/timeline/HoodieActiveTimeline.java
@@ -18,7 +18,6 @@ package com.uber.hoodie.common.table.timeline;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Sets;
-import com.google.common.io.Closeables;
 import com.uber.hoodie.common.table.HoodieTableMetaClient;
 import com.uber.hoodie.common.table.HoodieTimeline;
 import com.uber.hoodie.common.util.FSUtils;
@@ -303,16 +302,10 @@ public class HoodieActiveTimeline extends HoodieDefaultTimeline {
     }
 
     protected Optional<byte[]> readDataFromPath(Path detailPath) {
-        FSDataInputStream is = null;
-        try {
-            is = fs.open(detailPath);
+        try (FSDataInputStream is = fs.open(detailPath)) {
             return Optional.of(IOUtils.toByteArray(is));
         } catch (IOException e) {
             throw new HoodieIOException("Could not read commit details from " + detailPath, e);
-        } finally {
-            if (is != null) {
-                Closeables.closeQuietly(is);
-            }
         }
     }
 


### PR DESCRIPTION
@prazanna @vinothchandar 
These changes were necessary because we were running into issues where in our project google guava libraries are more recent and have Closeables.closeQuietly() removed (it was deprecated in v13 iirc).  This was causing dependency issues as methods were not found during runtime.  I changed this to a try with resources block instead so we don't have to manually call close() on the resource.  My assumption is that we weren't swallowing any exceptions so closeQuietly() wasn't necessary.  Will validate in staging before committing.