### PR TITLE
fix for cleaning log files in master branch (mor)

### DIFF
--- a/hoodie-common/src/main/java/com/uber/hoodie/common/util/FSUtils.java
+++ b/hoodie-common/src/main/java/com/uber/hoodie/common/util/FSUtils.java
@@ -18,13 +18,11 @@ package com.uber.hoodie.common.util;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
-
-import com.uber.hoodie.common.model.HoodiePartitionMetadata;
 import com.uber.hoodie.common.model.HoodieLogFile;
+import com.uber.hoodie.common.model.HoodiePartitionMetadata;
 import com.uber.hoodie.common.table.timeline.HoodieInstant;
 import com.uber.hoodie.exception.HoodieIOException;
 import com.uber.hoodie.exception.InvalidHoodiePathException;
-
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
@@ -54,6 +52,7 @@ public class FSUtils {
     private static final Logger LOG = LogManager.getLogger(FSUtils.class);
     // Log files are of this pattern - .b5068208-e1a4-11e6-bf01-fe55135034f3_20170101134598.log.1
     private static final Pattern LOG_FILE_PATTERN = Pattern.compile("\\.(.*)_(.*)\\.(.*)\\.([0-9]*)");
+    private static final String LOG_FILE_PREFIX = ".";
     private static final int MAX_ATTEMPTS_RECOVER_LEASE = 10;
     private static final long MIN_CLEAN_TO_KEEP = 10;
     private static final long MIN_ROLLBACK_TO_KEEP = 10;
@@ -228,11 +227,11 @@ public class FSUtils {
 
     public static String makeLogFileName(String fileId, String logFileExtension,
         String baseCommitTime, int version) {
-        return "." + String.format("%s_%s%s.%d", fileId, baseCommitTime, logFileExtension, version);
+        return LOG_FILE_PREFIX + String.format("%s_%s%s.%d", fileId, baseCommitTime, logFileExtension, version);
     }
 
     public static String maskWithoutLogVersion(String commitTime, String fileId, String logFileExtension) {
-        return String.format("%s_%s%s*", fileId, commitTime, logFileExtension);
+        return LOG_FILE_PREFIX + String.format("%s_%s%s*", fileId, commitTime, logFileExtension);
     }
 
 

--- a/hoodie-common/src/test/java/com/uber/hoodie/common/model/HoodieTestUtils.java
+++ b/hoodie-common/src/test/java/com/uber/hoodie/common/model/HoodieTestUtils.java
@@ -38,6 +38,7 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.LocatedFileStatus;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.RemoteIterator;
+import org.apache.hadoop.util.StringUtils;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.ByteArrayInputStream;
@@ -50,6 +51,7 @@ import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -111,8 +113,34 @@ public class HoodieTestUtils {
         return fileID;
     }
 
+    public static final String createNewLogFile(String basePath, String partitionPath, String commitTime, String fileID, Optional<Integer> version) throws IOException {
+        String folderPath = basePath + "/" + partitionPath + "/";
+        boolean makeDir = fs.mkdirs(new Path(folderPath));
+        if(!makeDir) {
+            throw new IOException("cannot create directory for path " + folderPath);
+        }
+        boolean createFile = fs.createNewFile(new Path(folderPath + FSUtils.makeLogFileName(fileID, ".log",commitTime, version.orElse(DEFAULT_TASK_PARTITIONID))));
+        if(!createFile) {
+            throw new IOException(StringUtils.format("cannot create data file for commit %s and fileId %s", commitTime, fileID));
+        }
+        return fileID;
+    }
+
+    public static final void createCompactionCommitFiles(String basePath, String... commitTimes) throws IOException {
+        for (String commitTime: commitTimes) {
+            boolean createFile = fs.createNewFile(new Path(basePath + "/" + HoodieTableMetaClient.METAFOLDER_NAME+ "/" + HoodieTimeline.makeCompactionFileName(commitTime)));
+            if(!createFile) {
+                throw new IOException("cannot create commit file for commit " + commitTime);
+            }
+        }
+    }
+
     public static final String getDataFilePath(String basePath, String partitionPath, String commitTime, String fileID) throws IOException {
         return basePath + "/" + partitionPath + "/" + FSUtils.makeDataFileName(commitTime, DEFAULT_TASK_PARTITIONID, fileID);
+    }
+
+    public static final String getLogFilePath(String basePath, String partitionPath, String commitTime, String fileID, Optional<Integer> version) throws IOException {
+        return basePath + "/" + partitionPath + "/" + FSUtils.makeLogFileName(fileID, ".log", commitTime, version.orElse(DEFAULT_TASK_PARTITIONID));
     }
 
     public static final String getCommitFilePath(String basePath, String commitTime) throws IOException {
@@ -121,6 +149,10 @@ public class HoodieTestUtils {
 
     public static final boolean doesDataFileExist(String basePath, String partitionPath, String commitTime, String fileID) throws IOException {
         return new File(getDataFilePath(basePath, partitionPath, commitTime, fileID)).exists();
+    }
+
+    public static final boolean doesLogFileExist(String basePath, String partitionPath, String commitTime, String fileID, Optional<Integer> version) throws IOException {
+        return new File(getLogFilePath(basePath, partitionPath, commitTime, fileID, version)).exists();
     }
 
     public static final boolean doesCommitExist(String basePath, String commitTime) {


### PR DESCRIPTION
@vinothchandar Used FileGroups abstraction to fix the clean() API for merge on read tabletype. We need a refactor to move this logic into each table so that MOR clean logic isn't part of COW. The scope of that issue is different and will do it as part of a different PR.

Once you review this, https://github.com/uber/hoodie/pull/217 PR can be closed.