### PR TITLE
Use CompletedFileSystemView instead of CompactedView considering deltacommits too

### DIFF
--- a/hoodie-client/src/main/java/com/uber/hoodie/io/HoodieCleanHelper.java
+++ b/hoodie-client/src/main/java/com/uber/hoodie/io/HoodieCleanHelper.java
@@ -59,7 +59,7 @@ public class HoodieCleanHelper<T extends HoodieRecordPayload<T>> {
 
     public HoodieCleanHelper(HoodieTable<T> hoodieTable, HoodieWriteConfig config) {
         this.hoodieTable = hoodieTable;
-        this.fileSystemView = hoodieTable.getCompactedFileSystemView();
+        this.fileSystemView = hoodieTable.getCompletedFileSystemView();
         this.commitTimeline = hoodieTable.getCompletedCommitTimeline();
         this.config = config;
         this.fs = hoodieTable.getFs();

--- a/hoodie-client/src/main/java/com/uber/hoodie/table/HoodieTable.java
+++ b/hoodie-client/src/main/java/com/uber/hoodie/table/HoodieTable.java
@@ -127,12 +127,12 @@ public abstract class HoodieTable<T extends HoodieRecordPayload> implements Seri
     }
 
     /**
-     * Get the view of the file system for this table
+     * Get the completed (commit + compaction) view of the file system for this table
      *
      * @return
      */
-    public TableFileSystemView getCompactedFileSystemView() {
-        return new HoodieTableFileSystemView(metaClient, getCompletedCompactionCommitTimeline());
+    public TableFileSystemView getCompletedFileSystemView() {
+        return new HoodieTableFileSystemView(metaClient, getCommitTimeline());
     }
 
     /**


### PR DESCRIPTION
@vinothchandar The clean() API uses `getCompactedFileSystemView()` which basically returns either `commit` for COW or `compaction` for MOR. If the timeline for MOR does not have any `compaction` and has only `deltacommits` we should not throw an exception.