### PR TITLE
Replacing SortBy with custom partitioner

### DIFF
--- a/hoodie-client/src/main/java/com/uber/hoodie/table/UserDefinedBulkInsertPartitioner.java
+++ b/hoodie-client/src/main/java/com/uber/hoodie/table/UserDefinedBulkInsertPartitioner.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2017 Uber Technologies, Inc. (hoodie-dev-group@uber.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.uber.hoodie.table;
+
+import com.uber.hoodie.common.model.HoodieRecord;
+import com.uber.hoodie.common.model.HoodieRecordPayload;
+import org.apache.spark.api.java.JavaRDD;
+
+/**
+ * Repartition input records into at least expected number of output spark partitions. It should give
+ * below guarantees
+ * - Output spark partition will have records from only one hoodie partition.
+ * - Average records per output spark partitions should be almost equal to (#inputRecords / #outputSparkPartitions)
+ * to avoid possible skews.
+ */
+public interface UserDefinedBulkInsertPartitioner<T extends HoodieRecordPayload> {
+
+    JavaRDD<HoodieRecord<T>> repartitionRecords(JavaRDD<HoodieRecord<T>> records, int outputSparkPartitions);
+}


### PR DESCRIPTION
Replacing bulkInsert sortby with custom partitioner such that;
- Single output spark partition doesn't have records from more than one hoodie partition.
- Trying to fit as many records with same hoodie partition as we can from same input spark partition into output spark partition.
@vinothchandar, @prazanna ,@n3nash , @jianxu