### PR TITLE
Use getFileStatus to get single FileStatus for single file

### DIFF
--- a/hoodie-common/src/main/java/com/uber/hoodie/common/util/FSUtils.java
+++ b/hoodie-common/src/main/java/com/uber/hoodie/common/util/FSUtils.java
@@ -112,7 +112,7 @@ public class FSUtils {
     }
 
     public static long getFileSize(FileSystem fs, Path path) throws IOException {
-        return fs.listStatus(path)[0].getLen();
+        return fs.getFileStatus(path).getLen();
     }
 
     public static String getFileId(String fullFileName) {


### PR DESCRIPTION

@vinothchandar @prazanna @n3nash 

I don't expect to see performance improvement for this change, this change is mainly to provide a more accurate number for directory list status RPC call.  The change is tested in Uber's data system.
