### PR TITLE
Update deprecated hash function

### DIFF
--- a/hoodie-client/src/main/java/com/uber/hoodie/table/HoodieCopyOnWriteTable.java
+++ b/hoodie-client/src/main/java/com/uber/hoodie/table/HoodieCopyOnWriteTable.java
@@ -360,7 +360,7 @@ public class HoodieCopyOnWriteTable<T extends HoodieRecordPayload> extends Hoodi
                 // pick the target bucket to use based on the weights.
                 double totalWeight = 0.0;
                 final long totalInserts = Math.max(1, globalStat.getNumInserts());
-                final double r = 1.0 * Math.floorMod(Hashing.md5().hashString(keyLocation._1().getRecordKey()).asLong(),
+                final double r = 1.0 * Math.floorMod(Hashing.md5().hashUnencodedChars(keyLocation._1().getRecordKey()).asLong(),
                     totalInserts) / totalInserts;
                 for (InsertBucket insertBucket: targetBuckets) {
                     totalWeight += insertBucket.weight;


### PR DESCRIPTION
Guava deprecated hashString(String) in v15, and removed it in v16.
Replace call with hashUnencodedString(String), which replace it, to
be compatible with newer versions of Guava.