### PR TITLE
(WIP) 1. Separating compaction() into a first level entity in HoodieWriteClient 2. Change for MOR metrics

### DIFF
--- a/hoodie-client/src/test/java/com/uber/hoodie/TestHoodieClientOnCopyOnWriteStorage.java
+++ b/hoodie-client/src/test/java/com/uber/hoodie/TestHoodieClientOnCopyOnWriteStorage.java
@@ -40,6 +40,7 @@ import com.uber.hoodie.common.util.FSUtils;
 import com.uber.hoodie.common.util.ParquetUtils;
 import com.uber.hoodie.config.HoodieCompactionConfig;
 import com.uber.hoodie.config.HoodieIndexConfig;
+import com.uber.hoodie.config.HoodieMetricsConfig;
 import com.uber.hoodie.config.HoodieStorageConfig;
 import com.uber.hoodie.config.HoodieWriteConfig;
 import com.uber.hoodie.exception.HoodieRollbackException;

--- a/hoodie-common/src/main/java/com/uber/hoodie/common/model/HoodieCompactionMetadata.java
+++ b/hoodie-common/src/main/java/com/uber/hoodie/common/model/HoodieCompactionMetadata.java
@@ -38,6 +38,7 @@ import org.codehaus.jackson.map.ObjectMapper;
 public class HoodieCompactionMetadata extends HoodieCommitMetadata {
   private static volatile Logger log = LogManager.getLogger(HoodieCompactionMetadata.class);
   protected HashMap<String, List<CompactionWriteStat>> partitionToCompactionWriteStats;
+  protected long compactionCommit;
 
   public HoodieCompactionMetadata() {
     partitionToCompactionWriteStats = new HashMap<>();
@@ -51,12 +52,50 @@ public class HoodieCompactionMetadata extends HoodieCommitMetadata {
     partitionToCompactionWriteStats.get(partitionPath).add(stat);
   }
 
+  public void setCompactionCommit(long compactionCommit) {
+    this.compactionCommit = compactionCommit;
+  }
+
+  public long getCompactionCommit() {
+    return this.compactionCommit;
+  }
+
   public List<CompactionWriteStat> getCompactionWriteStats(String partitionPath) {
     return partitionToCompactionWriteStats.get(partitionPath);
   }
 
   public Map<String, List<CompactionWriteStat>> getPartitionToCompactionWriteStats() {
     return partitionToCompactionWriteStats;
+  }
+
+  public Long getTotalLogRecordsCompacted() {
+    Long totalLogRecords = 0L;
+    for(Map.Entry<String, List<CompactionWriteStat>> entry : partitionToCompactionWriteStats.entrySet()) {
+      for (CompactionWriteStat cWriteStat : entry.getValue()) {
+        totalLogRecords += cWriteStat.getTotalLogRecords();
+      }
+    }
+    return totalLogRecords;
+  }
+
+  public Long getTotalLogFilesCompacted() {
+    Long totalLogFiles = 0L;
+    for(Map.Entry<String, List<CompactionWriteStat>> entry : partitionToCompactionWriteStats.entrySet()) {
+      for (CompactionWriteStat cWriteStat : entry.getValue()) {
+        totalLogFiles += cWriteStat.getTotalLogFiles();
+      }
+    }
+    return totalLogFiles;
+  }
+
+  public Long getTotalCompactedRecordsToBeUpdated() {
+    Long totalUpdateRecords = 0L;
+    for (Map.Entry<String, List<CompactionWriteStat>> entry : partitionToCompactionWriteStats.entrySet()) {
+      for (CompactionWriteStat cWriteStat : entry.getValue()) {
+        totalUpdateRecords += cWriteStat.getTotalRecordsToBeUpdate();
+      }
+    }
+    return totalUpdateRecords;
   }
 
   public String toJsonString() throws IOException {


### PR DESCRIPTION
@vinothchandar 
Few reasons for separating out compact() operation in HoodieWriteClient 

1. Ingestion jobs can run compact() at different schedules than from the ingestion job, for example every run or every 4 runs etc.
2. Ingestion jobs can choose to use different CompactionStrategies in these different schedules.
3. Conceptually, compaction should be an operation invoked by the client. Compaction is a commit of it's own, which means it should go through the process of creating a writeClient, startCommit etc through the client, thoughts ? 
4. Follow rollback of inflight commits before every action. Compaction being it's own commit (action) should invoke rollbackInFlightCommits() which is called during the writeClient invocation.  We could also call that method from inside the compact method without separating out compact() but that looks very hacky.

For the metrics, it's not the best solution. Need to think of a way again to refactor some of the metric classes <-> metadata binding, putting in this change for now, we can discuss alternate options too if this doesn't make sense.

I can separate compaction and metrics into 2 different diffs but wanted to get your feedback on both.